### PR TITLE
add PatternCostEstimator

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,6 @@ module github.com/juju/httpgovernor
 go 1.13
 
 require (
-	github.com/frankban/quicktest v1.7.3
+	github.com/frankban/quicktest v1.10.0
 	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e
 )

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,9 @@
-github.com/frankban/quicktest v1.7.3 h1:kV0lw0TH1j1hozahVmcpFCsbV5hcS4ZalH+U7UoeTow=
-github.com/frankban/quicktest v1.7.3/go.mod h1:V1d2J5pfxYH6EjBAgSK7YNXcXlTWxUHdE1sVDXkjnig=
+github.com/frankban/quicktest v1.10.0 h1:Gfh+GAJZOAoKZsIZeZbdn2JF10kN1XHNvjsvQK8gVkE=
+github.com/frankban/quicktest v1.10.0/go.mod h1:ui7WezCLWMWxVWr1GETZY3smRy0G4KWq9vcPtJmFl7Y=
 github.com/google/go-cmp v0.4.0 h1:xsAVV57WRhGj6kEIi8ReJzQlHHqcBYCElAvkovg3B/4=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
-github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
+github.com/kr/pretty v0.2.0 h1:s5hAObm+yFO5uHYt5dYjxi2rXrsnmRpJx4OYvIWUaQs=
+github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=

--- a/patternestimator.go
+++ b/patternestimator.go
@@ -1,0 +1,148 @@
+// Copyright 2020 Canonical Ltd.
+
+package httpgovernor
+
+import (
+	"net/http"
+	stdpath "path"
+	"strings"
+	"sync"
+)
+
+// A PattenCostEstimator determines the cost of a request by matching the
+// request against a list of configured patterns.
+//
+// The supported patterns are similar to the ones used in http.ServeMux.
+// A path must either be a rooted path, or a rooted subtree. As in
+// http.ServeMux the longest match takes precedence.
+//
+// A pattern may include a host before the path. If a host is specified
+// only requests addressed to that host will be matched. Any
+// host-specific match will take precedence over all-host matches.
+type PatternCostEstimator struct {
+	// mu is used to protect the fields in this structure.
+	mu sync.RWMutex
+
+	// costs contains the costs of paths supported by this estimator.
+	costs map[string]int64
+
+	// prefixes contain a list of prefixes that might be matched to
+	// identify costs. These are stored in order, longest to shortest
+	// so that more specific matches will be matched first.
+	prefixes []string
+
+	// hasHost stores whether any of the costs contain a host part.
+	// This allows the matcher to skip checking for matches with a
+	// host part, if it wouldn't match anything anyway.
+	hasHost bool
+}
+
+// EstimateCost determines the cost of the given request by matching in
+// the PatternCostEstimator. Any path not known is assumed to have a
+// cost of 1.
+func (c *PatternCostEstimator) EstimateCost(req *http.Request) int64 {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	path := stdpath.Clean(req.URL.Path)
+	if c.hasHost {
+		host := stripPort(req.Host)
+		cost, ok := c.match(host + path)
+		if ok {
+			return cost
+		}
+	}
+
+	cost, _ := c.match(path)
+	return cost
+}
+
+// stripPort removes a port from the http.Request.Host parameter, if
+// present.
+func stripPort(hostport string) string {
+	n := strings.LastIndexByte(hostport, ':')
+	if n == -1 {
+		return hostport
+	}
+	if hostport[0] == '[' && hostport[n-1] != ']' {
+		return hostport
+	}
+	return hostport[:n]
+}
+
+// match is used to match the given path (which might include a host) to
+// a cost. match should only be called with a read lock held.
+func (c *PatternCostEstimator) match(path string) (int64, bool) {
+	// first look for an exact match.
+	cost, ok := c.costs[path]
+	if ok {
+		return cost, true
+	}
+
+	// look for the longest matching prefix.
+	for _, prefix := range c.prefixes {
+		if strings.HasPrefix(path, prefix) {
+			return c.costs[prefix], true
+		}
+	}
+
+	// return the default cost of 1.
+	return 1, false
+}
+
+// SetCost configures the cost of a matched pattern.
+func (c *PatternCostEstimator) SetCost(path string, cost int64) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.costs == nil {
+		c.costs = make(map[string]int64)
+	}
+
+	var host string
+	n := strings.Index(path, "/")
+	switch n {
+	case -1:
+		host = path
+		path = "/"
+	case 0:
+		break
+	default:
+		host = path[:n]
+		path = path[n:]
+	}
+
+	prefix := strings.HasSuffix(path, "/")
+	path = stdpath.Clean(path)
+	if prefix && !strings.HasSuffix(path, "/") {
+		// Re-add the trailing slash
+		path += "/"
+	}
+	cleanPath := host + path
+
+	if host != "" {
+		c.hasHost = true
+	}
+	if prefix {
+		c.addPrefix(cleanPath)
+	}
+	c.costs[cleanPath] = cost
+}
+
+// addPrefix adds the prefix to the list of prefixes that will be matched
+// to a request. addPrefix expects to be called with the write lock held.
+func (c *PatternCostEstimator) addPrefix(prefix string) {
+	for i, p := range c.prefixes {
+		if p == prefix {
+			return
+		}
+		if len(prefix) > len(p) {
+			c.prefixes = append(c.prefixes, "")
+			copy(c.prefixes[i+1:], c.prefixes[i:])
+			c.prefixes[i] = prefix
+			return
+		}
+	}
+
+	// If we make it this far the prefix has to go on the end.
+	c.prefixes = append(c.prefixes, prefix)
+}

--- a/patternestimator_test.go
+++ b/patternestimator_test.go
@@ -1,0 +1,163 @@
+// Copyright 2020 Canonical Ltd.
+
+package httpgovernor_test
+
+import (
+	"net/http"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/juju/httpgovernor"
+)
+
+var _ httpgovernor.CostEstimator = (*httpgovernor.PatternCostEstimator)(nil)
+
+var pathCostTests = []struct {
+	name       string
+	costs      map[string]int64
+	host       string
+	path       string
+	expectCost int64
+}{{
+	name:       "empty",
+	path:       "/",
+	expectCost: 1,
+}, {
+	name: "exact_path",
+	costs: map[string]int64{
+		"/":     10,
+		"/free": 0,
+		"/api":  5,
+	},
+	path:       "/api",
+	expectCost: 5,
+}, {
+	name: "zero_cost",
+	costs: map[string]int64{
+		"/":     10,
+		"/free": 0,
+		"/api":  5,
+	},
+	path:       "/free",
+	expectCost: 0,
+}, {
+	name: "prefix_match",
+	costs: map[string]int64{
+		"/":     10,
+		"/free": 0,
+		"/api/": 5,
+	},
+	path:       "/api/call",
+	expectCost: 5,
+}, {
+	name: "no_match",
+	costs: map[string]int64{
+		"/free": 0,
+		"/api":  5,
+	},
+	path:       "/nomatch",
+	expectCost: 1,
+}, {
+	name: "host_match",
+	costs: map[string]int64{
+		"test2.example.com": 10,
+	},
+	host:       "test2.example.com",
+	path:       "/",
+	expectCost: 10,
+}, {
+	name: "host_path",
+	costs: map[string]int64{
+		"test2.example.com/free": 0,
+		"test2.example.com/api/": 5,
+	},
+	host:       "test2.example.com",
+	path:       "/api/call",
+	expectCost: 5,
+}, {
+	name: "host_not_matched",
+	costs: map[string]int64{
+		"test2.example.com/free": 0,
+		"test2.example.com/api":  5,
+	},
+	path:       "/api/call",
+	expectCost: 1,
+}, {
+	name: "ip_host",
+	costs: map[string]int64{
+		"127.0.0.1/free": 0,
+		"127.0.0.1/api/": 5,
+	},
+	host:       "127.0.0.1",
+	path:       "/api/call",
+	expectCost: 5,
+}, {
+	name: "ip6_host",
+	costs: map[string]int64{
+		"[::1]/free": 0,
+		"[::1]/api/": 5,
+	},
+	host:       "[::1]",
+	path:       "/api/call",
+	expectCost: 5,
+}, {
+	name: "ip_hostport",
+	costs: map[string]int64{
+		"127.0.0.1/free": 0,
+		"127.0.0.1/api/": 5,
+	},
+	host:       "127.0.0.1:80",
+	path:       "/api/call",
+	expectCost: 5,
+}, {
+	name: "ip6_hostport",
+	costs: map[string]int64{
+		"[::1]/free": 0,
+		"[::1]/api/": 5,
+	},
+	host:       "[::1]:80",
+	path:       "/api/call",
+	expectCost: 5,
+}, {
+	name: "longest_match",
+	costs: map[string]int64{
+		"/free":       0,
+		"/api/":       5,
+		"/api/calls/": 7,
+	},
+	host:       "[::1]:80",
+	path:       "/api/calls/call1",
+	expectCost: 7,
+}}
+
+func TestPathEstimator(t *testing.T) {
+	c := qt.New(t)
+
+	for _, test := range pathCostTests {
+		c.Run(test.name, func(c *qt.C) {
+			pce := new(httpgovernor.PatternCostEstimator)
+			for path, cost := range test.costs {
+				pce.SetCost(path, cost)
+			}
+			if test.host == "" {
+				test.host = "test.example.com"
+			}
+			req, err := http.NewRequest("GET", "http://"+test.host+test.path, nil)
+			c.Assert(err, qt.IsNil)
+			cost := pce.EstimateCost(req)
+			c.Check(cost, qt.Equals, test.expectCost)
+		})
+	}
+}
+
+func TestSetCostMultiple(t *testing.T) {
+	c := qt.New(t)
+
+	pce := new(httpgovernor.PatternCostEstimator)
+	pce.SetCost("/api/", 5)
+	pce.SetCost("/api/", 7)
+	req, err := http.NewRequest("GET", "http://example.com/api/call", nil)
+	c.Assert(err, qt.IsNil)
+	c.Check(pce.EstimateCost(req), qt.Equals, int64(7))
+}


### PR DESCRIPTION
Add a CostEstimator that matches requests in the same way as in
http.ServeMux. This provides a richer cost estimating interface.